### PR TITLE
Move @types/keyv to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "url": "https://github.com/szmarczak/cacheable-lookup/issues"
   },
   "homepage": "https://github.com/szmarczak/cacheable-lookup#readme",
+  "dependencies": {
+    "@types/keyv": "^3.1.1"
+  },
   "devDependencies": {
-    "@types/keyv": "^3.1.1",
     "ava": "^3.1.0",
     "benchmark": "^2.1.4",
     "coveralls": "^3.0.9",


### PR DESCRIPTION
## Motivation

Running a typecheck with Yarn 2 failed because of missing types.
![Screenshot 2020-03-20 at 11 03 03](https://user-images.githubusercontent.com/597828/77154180-7f832e00-6a9b-11ea-8448-ecb166c4ff53.png)

## Changes

- moved `@types/keyv` to dependencies