### PR TITLE
New option to return only one ip when we resolve to multiple addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ Default: `undefined` (OS-specific)
 
 The full path to the `hosts` file. Set this to `false` to prevent loading entries from the `hosts` file.
 
-##### options.randomEntry
+##### options.firstEntry
 
 Type: `boolean`<br>
-Default: `true`
+Default: `false`
 
-If the host resolves to multiple ip's, return each time a random ip address. Set this to `false` to always return the same ip.
+If the host resolves to multiple ip's, return only the first one.
 
 ### Entry object
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Default: `undefined` (OS-specific)
 
 The full path to the `hosts` file. Set this to `false` to prevent loading entries from the `hosts` file.
 
+##### options.randomEntry
+
+Type: `boolean`<br>
+Default: `true`
+
+If the host resolves to multiple ip's, return each time a random ip address. Set this to `false` to always return the same ip.
+
 ### Entry object
 
 Type: `object`

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,9 +38,9 @@ export interface Options {
 	/**
 	 * If the host resolves to multiple ip's, return each time a random ip address.
 	 * Set this to `false` to always return the same ip.
-	 * @default true
+	 * @default false
 	 */
-	randomEntry: true;
+	firstEntry: false;
 	/**
 	 * The lifetime of the entries received from the OS (TTL in seconds).
 	 *

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,12 @@ export interface Options {
 	 */
 	customHostsPath?: string | false;
 	/**
+	 * If the host resolves to multiple ip's, return each time a random ip address.
+	 * Set this to `false` to always return the same ip.
+	 * @default true
+	 */
+	randomEntry: true;
+	/**
 	 * The lifetime of the entries received from the OS (TTL in seconds).
 	 *
 	 * **Note**: This option is independent, `options.maxTtl` does not affect this.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -11,7 +11,7 @@ import CacheableLookup, {EntryObject} from '.';
 	new CacheableLookup({
 		cache: new Keyv(),
 		customHostsPath: false,
-		randomEntry: true,
+		firstEntry: false,
 		fallbackTtl: 0,
 		errorTtl: 0,
 		maxTtl: 0,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -11,6 +11,7 @@ import CacheableLookup, {EntryObject} from '.';
 	new CacheableLookup({
 		cache: new Keyv(),
 		customHostsPath: false,
+		randomEntry: true,
 		fallbackTtl: 0,
 		errorTtl: 0,
 		maxTtl: 0,

--- a/source/index.js
+++ b/source/index.js
@@ -57,6 +57,7 @@ const ttl = {ttl: true};
 class CacheableLookup {
 	constructor({
 		customHostsPath,
+		randomEntry = true,
 		cache = new Map(),
 		maxTtl = Infinity,
 		resolver = new AsyncResolver(),
@@ -66,6 +67,7 @@ class CacheableLookup {
 		this.maxTtl = maxTtl;
 		this.fallbackTtl = fallbackTtl;
 		this.errorTtl = errorTtl;
+		this.randomEntry = randomEntry;
 
 		// This value is in milliseconds
 		this._lockTime = Math.max(Math.floor(Math.min(this.fallbackTtl * 1000, this.errorTtl * 1000)), 10);
@@ -165,7 +167,7 @@ class CacheableLookup {
 			return cached;
 		}
 
-		if (cached.length === 1) {
+		if (cached.length === 1 || !this.randomEntry) {
 			return cached[0];
 		}
 

--- a/source/index.js
+++ b/source/index.js
@@ -57,7 +57,7 @@ const ttl = {ttl: true};
 class CacheableLookup {
 	constructor({
 		customHostsPath,
-		randomEntry = true,
+		firstEntry = false,
 		cache = new Map(),
 		maxTtl = Infinity,
 		resolver = new AsyncResolver(),
@@ -67,7 +67,7 @@ class CacheableLookup {
 		this.maxTtl = maxTtl;
 		this.fallbackTtl = fallbackTtl;
 		this.errorTtl = errorTtl;
-		this.randomEntry = randomEntry;
+		this.firstEntry = firstEntry;
 
 		// This value is in milliseconds
 		this._lockTime = Math.max(Math.floor(Math.min(this.fallbackTtl * 1000, this.errorTtl * 1000)), 10);
@@ -167,7 +167,7 @@ class CacheableLookup {
 			return cached;
 		}
 
-		if (cached.length === 1 || !this.randomEntry) {
+		if (cached.length === 1 || this.firstEntry) {
 			return cached[0];
 		}
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -256,8 +256,8 @@ test.serial('multiple entries', async t => {
 	Math.random = random;
 });
 
-test.serial('multiple entries when `options.randomEntry` is falsy, then we always resolve to the first entry', async t => {
-	const cacheable = new CacheableLookup({resolver, customHostsPath: false, randomEntry: false});
+test.serial('multiple entries when `options.firstEntry` is true, then we always resolve to the first entry', async t => {
+	const cacheable = new CacheableLookup({resolver, customHostsPath: false, firstEntry: true});
 
 	const {random} = Math;
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -256,6 +256,36 @@ test.serial('multiple entries', async t => {
 	Math.random = random;
 });
 
+test.serial('multiple entries when `options.randomEntry` is falsy, then we always resolve to the first entry', async t => {
+	const cacheable = new CacheableLookup({resolver, customHostsPath: false, randomEntry: false});
+
+	const {random} = Math;
+
+	{
+		// Let's fool the destiny
+		Math.random = () => 0;
+		const entry = await cacheable.lookupAsync('multiple');
+
+		verify(t, entry, {
+			address: '127.0.0.127',
+			family: 4
+		});
+	}
+
+	{
+		// Let's fool the destiny
+		Math.random = () => 0.6;
+		const entry = await cacheable.lookupAsync('multiple');
+
+		verify(t, entry, {
+			address: '127.0.0.127',
+			family: 4
+		});
+	}
+
+	Math.random = random;
+});
+
 test('if `options.all` is falsy, then `options.family` is 4 when not defined', async t => {
 	const cacheable = new CacheableLookup({resolver, customHostsPath: false});
 


### PR DESCRIPTION
This is kind of a corner case. At our company we use Got to make several thousand API calls/s to our partners. In our case, some of those partners domains resolve to multiple ip addresses (one of them to more than 70).

Obviously we need a DNS caching mechanism, but the problem is, when a domain resolves to multiple ip's, the caching just returns a random address each time. This is fine when the traffic is low but in our case this decreases performance as the system is constantly opening up new connections to new ips and the old ones don't get reused even though we set them to keepalive because they are targeting different addresses.

This option is just a single flag that, when enabled always returns the first entry. Obviously it's disabled by default. 