### PR TITLE
Fix promise not being removed from queue on fallback query

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -206,7 +206,11 @@ class CacheableLookup {
 				const newPromise = this.queryAndCache(hostname);
 				this._pending[hostname] = newPromise;
 
-				cached = await newPromise;
+				try {
+					cached = await newPromise;
+				} finally {
+					delete this._pending[hostname];
+				}
 			}
 		}
 
@@ -317,34 +321,24 @@ class CacheableLookup {
 
 	async queryAndCache(hostname) {
 		if (this._hostnamesToFallback.has(hostname)) {
-			const entries = await this._dnsLookup(hostname, all);
-			delete this._pending[hostname];
-			return entries;
+			return this._dnsLookup(hostname, all);
 		}
 
-		try {
-			let query = await this._resolve(hostname);
+		let query = await this._resolve(hostname);
 
-			if (query.entries.length === 0 && this._fallback) {
-				query = await this._lookup(hostname);
+		if (query.entries.length === 0 && this._fallback) {
+			query = await this._lookup(hostname);
 
-				if (query.entries.length !== 0) {
-					// Use `dns.lookup(...)` for that particular hostname
-					this._hostnamesToFallback.add(hostname);
-				}
+			if (query.entries.length !== 0) {
+				// Use `dns.lookup(...)` for that particular hostname
+				this._hostnamesToFallback.add(hostname);
 			}
-
-			const cacheTtl = query.entries.length === 0 ? this.errorTtl : query.cacheTtl;
-			await this._set(hostname, query.entries, cacheTtl);
-
-			delete this._pending[hostname];
-
-			return query.entries;
-		} catch (error) {
-			delete this._pending[hostname];
-
-			throw error;
 		}
+
+		const cacheTtl = query.entries.length === 0 ? this.errorTtl : query.cacheTtl;
+		await this._set(hostname, query.entries, cacheTtl);
+
+		return query.entries;
 	}
 
 	_tick(ms) {

--- a/source/index.js
+++ b/source/index.js
@@ -317,7 +317,9 @@ class CacheableLookup {
 
 	async queryAndCache(hostname) {
 		if (this._hostnamesToFallback.has(hostname)) {
-			return this._dnsLookup(hostname, all);
+			const entries = await this._dnsLookup(hostname, all);
+			delete this._pending[hostname];
+			return entries;
 		}
 
 		try {

--- a/tests/test.js
+++ b/tests/test.js
@@ -792,7 +792,7 @@ test.serial('fallback works', async t => {
 	});
 });
 
-test('fallback works if ip change', async t => {
+test.serial('fallback works if ip change', async t => {
 	const cacheable = new CacheableLookup({resolver, fallbackDuration: 3600});
 	resolver.resetCounter();
 	resolver.lookupData.osHostnameChange = [

--- a/tests/test.js
+++ b/tests/test.js
@@ -792,8 +792,6 @@ test.serial('fallback works', async t => {
 	});
 });
 
-
-
 test('fallback works if ip change', async t => {
 	const cacheable = new CacheableLookup({resolver, fallbackDuration: 3600});
 	resolver.resetCounter();


### PR DESCRIPTION
Always delete entries from _pending when promise is resolved

In the `queryAndCache` function, `_pending` entries are deleted at return but not in fallback mode. So in fallback mode, _dnsLookup is called only once. Thus, name resolution remains in an old state.

Add a test for demonstration. 