### PR TITLE
Fallback to dns.lookup for IPv4 & IPv6 separately

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -788,7 +788,7 @@ test.serial('fallback works', async t => {
 	t.deepEqual(resolver.counter, {
 		6: 1,
 		4: 1,
-		lookup: 2
+		lookup: 3
 	});
 
 	await sleep(100);
@@ -1015,12 +1015,21 @@ test('slow dns.lookup', async t => {
 		resolver,
 		lookup: (hostname, options, callback) => {
 			t.is(hostname, 'osHostname');
-			t.deepEqual(options, {all: true});
+			t.is(options.all, true);
+			t.true(options.family === 4 || options.family === 6);
 
 			setTimeout(() => {
-				callback(null, [
-					{address: '127.0.0.1', family: 4}
-				]);
+				if (options.family === 4) {
+					callback(null, [
+						{address: '127.0.0.1', family: 4}
+					]);
+				}
+
+				if (options.family === 6) {
+					callback(null, [
+						{address: '::1', family: 6}
+					]);
+				}
 			}, 10);
 		}
 	});


### PR DESCRIPTION
This fixes #42.

I'm not sure how to test it without adding significantly more complex logic to the dns.lookup mock, and I'm not sure if you'd want that? For now I've just updated the existing tests that cover this, and they still seem to pass happily.

I have tested this manually, using the /etc/hosts configuration and repro code from #42. With this change, the code there now returns the expected result: returning the same IPv6 result as `
dns.lookup('localhost', { family: 6 }`.

I'm not totally confident that double-requesting like this won't produce some other strange side-effects in other edge cases. I'm not really familiar with this codebase or the oddities of the DNS API, so a detailed review would be very helpful!