### PR TITLE
Handle ENOENT Windows lookup failures

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -65,7 +65,11 @@ const isIterable = map => {
 
 const ignoreNoResultErrors = dnsPromise => {
 	return dnsPromise.catch(error => {
-		if (error.code === 'ENODATA' || error.code === 'ENOTFOUND') {
+		if (
+			error.code === 'ENODATA' ||
+			error.code === 'ENOTFOUND' ||
+			error.code === 'ENOENT' // Windows: name exists, but not this record type
+		) {
 			return [];
 		}
 


### PR DESCRIPTION
Fixes #49

This can happen when, for example, you query with `{family:6}` on Windows but only IPv4 resolution is available.

It's very difficult to pin down all the possible error cases for DNS, but I think this happens because:

* `uv__getaddrinfo_translate_error` in libuv for Windows falls back to `uv_translate_sys_error` ([here](https://github.com/libuv/libuv/blob/47e0c5c575e92a25e0da10fc25b2732942c929f3/src/win/getaddrinfo.c#L35-L48))
* `uv_translate_sys_error` maps `WSANO_DATA` to `ENOENT` ([here](https://github.com/libuv/libuv/blob/46451737e6174281317cabdf05c9ba1434c359d6/src/win/error.c#L143))
* `WSANO_DATA` is returned by Windows when the name exists, but not the requested record type. See https://docs.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2, which says:
  > The requested name is valid and was found in the database, but it does not have the correct associated data being resolved for. The usual example for this is a host name-to-address translation attempt (using gethostbyname or WSAAsyncGetHostByName) which uses the DNS (Domain Name Server). An MX record is returned but no A record—indicating the host itself exists, but is not directly reachable.

This shouldn't ever be returned on Unix OSs, which have their own separate & fixed list of possible errors ([here](https://github.com/libuv/libuv/blob/5c19f73aa206fcd2be55e2f20aaa8939b3cc5ff9/src/unix/getaddrinfo.c#L39-L95)).

There's more discussion and an (unmerged) PR to fix this properly and line up Unix & Windows DNS error handling here: https://github.com/libuv/libuv/issues/2959