### PR TITLE
Add entry source, either cache or query

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ The timestamp (`Date.now() + ttl * 1000`) when the entry expires.
 
 The time in seconds for its lifetime.
 
+#### source
+
+**Note**: This is not present when falling back to `dns.lookup(...)`!
+
+Whether this entry was loaded from the cache or came from a query (`cache` or `query`)
+
 ### Entry object (callback-style)
 
 When `options.all` is `false`, then `callback(error, address, family, expires, ttl)` is called. <br>

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import {Agent} from 'http';
 type AsyncResolver = dnsPromises.Resolver;
 
 export type IPFamily = 4 | 6;
+export type EntrySource = 'query' | 'cache';
 
 type TPromise<T> = T | Promise<T>;
 
@@ -72,6 +73,10 @@ export interface EntryObject {
 	 * The expiration timestamp.
 	 */
 	readonly expires?: number;
+	/**
+	 * Whether this entry comes from the cache or a query
+	 */
+	readonly source?: EntrySource;
 }
 
 export interface LookupOptions {

--- a/source/index.js
+++ b/source/index.js
@@ -160,7 +160,7 @@ class CacheableLookup {
 			if (options.all) {
 				callback(null, result);
 			} else {
-				callback(null, result.address, result.family, result.expires, result.ttl);
+				callback(null, result.address, result.family, result.expires, result.ttl, result.source);
 			}
 		}, callback);
 	}
@@ -211,6 +211,7 @@ class CacheableLookup {
 	}
 
 	async query(hostname) {
+		let source = 'cache';
 		let cached = await this._cache.get(hostname);
 
 		if (!cached) {
@@ -219,6 +220,7 @@ class CacheableLookup {
 			if (pending) {
 				cached = await pending;
 			} else {
+				source = 'query';
 				const newPromise = this.queryAndCache(hostname);
 				this._pending[hostname] = newPromise;
 
@@ -231,7 +233,7 @@ class CacheableLookup {
 		}
 
 		cached = cached.map(entry => {
-			return {...entry};
+			return {...entry, source};
 		});
 
 		return cached;


### PR DESCRIPTION
When adding instrumentation around DNS lookups, it would be very helpful to be able to distinguish if an entry came from the cache or a fresh query. This would allow to compute the cache hit rate and to calculate stats on the duration of DNS queries, ignoring when the cache is hit.

The `source` is either `cache` or `query`. It is returned with the entry from `lookupAsync` and it is added as an extra parameter to the callback from `lookup`.

I didn't add the `source` parameter to the callback type definitions in https://github.com/szmarczak/cacheable-lookup/blob/master/index.d.ts#L102-L105 since the `expires` and `ttl` were already omitted. I wasn't sure if that was on purpose or if it was an omission.