### PR TITLE
Add stats for `query` and `cache` requests

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -215,19 +215,23 @@ class CacheableLookup {
 	}
 
 	async query(hostname) {
-		this.stats.query++;
 		let source = 'cache';
 		let cached = await this._cache.get(hostname);
+
+		if (cached) {
+			this.stats.cache++;
+		}
 
 		if (!cached) {
 			const pending = this._pending[hostname];
 			if (pending) {
+				this.stats.cache++;
 				cached = await pending;
 			} else {
 				source = 'query';
 				const newPromise = this.queryAndCache(hostname);
 				this._pending[hostname] = newPromise;
-				this.stats.cache++;
+				this.stats.query++;
 				try {
 					cached = await newPromise;
 				} finally {

--- a/source/index.js
+++ b/source/index.js
@@ -141,6 +141,10 @@ class CacheableLookup {
 		return this._resolver.getServers();
 	}
 
+	get numberOfCachedCalls() {
+		return this._cache.size
+	}
+
 	lookup(hostname, options, callback) {
 		if (typeof options === 'function') {
 			callback = options;

--- a/tests/test.js
+++ b/tests/test.js
@@ -1071,29 +1071,23 @@ test.cb.failing('throws original lookup error if not recognized', t => {
 test('cache and query stats', async t => {
 	const cacheable = new CacheableLookup({resolver});
 
-	let entries = await cacheable.lookupAsync('1dot1dot1dot1.cloudflare-dns.com', {all: true, family: 4});
+	t.is(cacheable.stats.query, 0);
+	t.is(cacheable.stats.cache, 0);
+
+	let entries = await cacheable.lookupAsync('temporary', {all: true, family: 4});
 	verify(t, entries, [
-		{family: 4, source: 'query'}
+		{address: '127.0.0.1', family: 4, source: 'query'}
 	]);
 
 	t.is(cacheable.stats.query, 1);
 	t.is(cacheable.stats.cache, 0);
 
-	entries = await cacheable.lookupAsync('1dot1dot1dot1.cloudflare-dns.com', {all: true, family: 4});
+	entries = await cacheable.lookupAsync('temporary', {all: true, family: 4});
 
 	verify(t, entries, [
-		{family: 4, source: 'cache'}
+		{address: '127.0.0.1', family: 4, source: 'cache'}
 	]);
 
 	t.is(cacheable.stats.query, 1);
-	t.is(cacheable.stats.cache, 1);
-
-	entries = await cacheable.lookupAsync('google.com', {all: true, family: 4});
-
-	verify(t, entries, [
-		{family: 4, source: 'query'}
-	]);
-
-	t.is(cacheable.stats.query, 2);
 	t.is(cacheable.stats.cache, 1);
 });

--- a/tests/test.js
+++ b/tests/test.js
@@ -1069,19 +1069,31 @@ test.cb.failing('throws original lookup error if not recognized', t => {
 });
 
 test('cache and query stats', async t => {
-	const cacheable = new CacheableLookup();
-	t.is(cacheable.stats.query, 0);
+	const cacheable = new CacheableLookup({resolver});
+
+	let entries = await cacheable.lookupAsync('1dot1dot1dot1.cloudflare-dns.com', {all: true, family: 4});
+	verify(t, entries, [
+		{family: 4, source: 'query'}
+	]);
+
+	t.is(cacheable.stats.query, 1);
 	t.is(cacheable.stats.cache, 0);
 
-	await cacheable.lookupAsync('1dot1dot1dot1.cloudflare-dns.com');
+	entries = await cacheable.lookupAsync('1dot1dot1dot1.cloudflare-dns.com', {all: true, family: 4});
+
+	verify(t, entries, [
+		{family: 4, source: 'cache'}
+	]);
+
 	t.is(cacheable.stats.query, 1);
 	t.is(cacheable.stats.cache, 1);
 
-	await cacheable.lookupAsync('1dot1dot1dot1.cloudflare-dns.com');
+	entries = await cacheable.lookupAsync('google.com', {all: true, family: 4});
+
+	verify(t, entries, [
+		{family: 4, source: 'query'}
+	]);
+
 	t.is(cacheable.stats.query, 2);
 	t.is(cacheable.stats.cache, 1);
-
-	await cacheable.lookupAsync('google.com');
-	t.is(cacheable.stats.query, 3);
-	t.is(cacheable.stats.cache, 2);
 });

--- a/tests/test.js
+++ b/tests/test.js
@@ -1067,3 +1067,21 @@ test.cb.failing('throws original lookup error if not recognized', t => {
 		t.end();
 	});
 });
+
+test('cache and query stats', async t => {
+	const cacheable = new CacheableLookup();
+	t.is(cacheable.stats.query, 0);
+	t.is(cacheable.stats.cache, 0);
+
+	await cacheable.lookupAsync('1dot1dot1dot1.cloudflare-dns.com');
+	t.is(cacheable.stats.query, 1);
+	t.is(cacheable.stats.cache, 1);
+
+	await cacheable.lookupAsync('1dot1dot1dot1.cloudflare-dns.com');
+	t.is(cacheable.stats.query, 2);
+	t.is(cacheable.stats.cache, 1);
+
+	await cacheable.lookupAsync('google.com');
+	t.is(cacheable.stats.query, 3);
+	t.is(cacheable.stats.cache, 2);
+});


### PR DESCRIPTION
Issue #64  

I implemented ```get``` method to get the size of cached calls: 

```javascript
get numberOfCachedCalls() {
    return this._cache.size
}
```