### PR TITLE
feat: allow custom resolver

### DIFF
--- a/source/index.mjs
+++ b/source/index.mjs
@@ -2,6 +2,7 @@ import {
 	V4MAPPED,
 	ADDRCONFIG,
 	ALL,
+	Resolver as SyncResolver,
 	promises as dnsPromises,
 	lookup as dnsLookup
 } from 'node:dns';
@@ -101,7 +102,7 @@ export default class CacheableLookup {
 			query: 0
 		};
 
-		if (this._resolver instanceof AsyncResolver) {
+		if (this._resolver instanceof AsyncResolver || !(this._resolver instanceof SyncResolver)) {
 			this._resolve4 = this._resolver.resolve4.bind(this._resolver);
 			this._resolve6 = this._resolver.resolve6.bind(this._resolver);
 		} else {


### PR DESCRIPTION
This allows a custom resolver that is not from the built-in `dns` package, with the assumption of a Promise-based custom resolver.  If support is desired for both, we would need `isPromise` detection on the binding of `resolve4` and `resolv6`.