### PR TITLE
fix: allow destroying a cache instance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,4 +141,8 @@ export default class CacheableLookup {
 	 * Clears the cache for the given hostname. If the hostname argument is not present, the entire cache will be emptied.
 	 */
 	clear(hostname?: string): void;
+  /**
+   * Clears underlying timers and the cache.
+   */
+  destroy(): void;
 }

--- a/source/index.mjs
+++ b/source/index.mjs
@@ -449,4 +449,9 @@ export default class CacheableLookup {
 
 		this._cache.clear();
 	}
+
+  destroy() {
+    this.clear();
+    clearInterval(this._fallbackInterval);
+  }
 }


### PR DESCRIPTION
Currently the cache instance creates an interval under the hood and there's no way to clear this interval. This effectively results in memory leaks when e.g. running a jest test suite where each suite creates a cache instance.