### PR TITLE
Only await cache#get if it's a promise

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,6 +1,6 @@
 import dns from 'node:dns';
 import Benchmark from 'benchmark';
-import CacheableLookup from './source/index.js';
+import CacheableLookup from './source/index.mjs';
 
 const cacheable = new CacheableLookup();
 const suite = new Benchmark.Suite();

--- a/source/index.mjs
+++ b/source/index.mjs
@@ -76,6 +76,10 @@ const ignoreNoResultErrors = dnsPromise => {
 	});
 };
 
+const isProm = value => {
+	return Boolean(value && typeof value.then === 'function');
+}
+
 const ttl = {ttl: true};
 const all = {all: true};
 const all4 = {all: true, family: 4};
@@ -215,7 +219,13 @@ export default class CacheableLookup {
 
 	async query(hostname) {
 		let source = 'cache';
-		let cached = await this._cache.get(hostname);
+		let maybeProm = this._cache.get(hostname);
+
+		if( isProm( maybeProm ) ) {
+			maybeProm = await maybeProm;
+		}
+
+		let cached = maybeProm;
 
 		if (cached) {
 			this.stats.cache++;


### PR DESCRIPTION
This is admittedly a pretty small optimization ( _maybe 5%_ ), but I figure I'd open a PR since I noticed it. I haven't fully tested this, but if there's interest in merging this I'll add some unit tests.

Ran the benchmark and got the following results:
### Before

```
CacheableLookup#lookupAsync x 528,392 ops/sec ±0.52% (90 runs sampled)
CacheableLookup#lookupAsync.all x 532,076 ops/sec ±0.30% (89 runs sampled)
CacheableLookup#lookupAsync.all.ADDRCONFIG x 426,854 ops/sec ±0.41% (89 runs sampled)
CacheableLookup#lookup x 510,691 ops/sec ±0.61% (89 runs sampled)
CacheableLookup#lookup.all x 503,598 ops/sec ±0.61% (89 runs sampled)
CacheableLookup#lookup.all.ADDRCONFIG x 420,734 ops/sec ±0.47% (90 runs sampled)
dns#lookup x 2,782 ops/sec ±3.95% (67 runs sampled)
dns#lookup.all x 3,182 ops/sec ±6.14% (75 runs sampled)
dns#lookup.all.ADDRCONFIG x 2,448 ops/sec ±2.92% (69 runs sampled)
```

### After

```
CacheableLookup#lookupAsync x 552,957 ops/sec ±0.62% (86 runs sampled)
CacheableLookup#lookupAsync.all x 556,641 ops/sec ±0.50% (89 runs sampled)
CacheableLookup#lookupAsync.all.ADDRCONFIG x 438,904 ops/sec ±0.46% (89 runs sampled)
CacheableLookup#lookup x 533,336 ops/sec ±0.54% (86 runs sampled)
CacheableLookup#lookup.all x 533,434 ops/sec ±0.57% (85 runs sampled)
CacheableLookup#lookup.all.ADDRCONFIG x 432,496 ops/sec ±0.51% (88 runs sampled)
dns#lookup x 2,378 ops/sec ±3.45% (69 runs sampled)
dns#lookup.all x 2,834 ops/sec ±5.86% (74 runs sampled)
dns#lookup.all.ADDRCONFIG x 2,656 ops/sec ±5.46% (65 runs sampled)
```